### PR TITLE
only show ingredient time information if ingredient type == "hop"

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "BrewTracker",
     "slug": "brewtracker-android",
     "orientation": "portrait",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "icon": "./assets/images/icon.png",
     "scheme": "brewtracker",
     "userInterfaceStyle": "automatic",
@@ -18,7 +18,7 @@
       },
       "edgeToEdgeEnabled": true,
       "package": "com.brewtracker.android",
-      "versionCode": 4,
+      "versionCode": 5,
       "permissions": [
         "CAMERA",
         "WRITE_EXTERNAL_STORAGE",

--- a/app/(modals)/(recipes)/viewRecipe.tsx
+++ b/app/(modals)/(recipes)/viewRecipe.tsx
@@ -173,15 +173,17 @@ export default function ViewRecipeScreen() {
           {ingredients.map((ingredient, index) => (
             <View key={ingredient.id || index} style={styles.ingredientItem}>
               <Text style={styles.ingredientName}>{ingredient.name}</Text>
-              <Text style={styles.ingredientAmount}>
+                <Text style={styles.ingredientAmount}>
                 {ingredient.amount} {ingredient.unit}
-                {ingredient.time &&
+                {/* Only show time if hops */}
+                {ingredient.type === "hop" &&
+                  ingredient.time &&
                   ingredient.time > 0 &&
                   ` • ${ingredient.time} min`}
                 {ingredient.alpha_acid && ` • ${ingredient.alpha_acid}% AA`}
                 {ingredient.attenuation &&
                   ` • ${ingredient.attenuation}% Attenuation`}
-              </Text>
+                </Text>
             </View>
           ))}
         </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brewtracker",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brewtracker",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brewtracker",
   "main": "expo-router/entry",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "license": "GPL-3.0-or-later",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
For some reason lots of recipeIngredients are being created with time = 0 which was causing the 0 to be included after amount unit but wasn't rendering the • or "min"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ingredient time values are now displayed only for hops in recipe details, improving clarity when viewing ingredient information.

* **Chores**
  * Updated app version to 0.5.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->