### PR TITLE
Add offline awareness to AI button and update offline FG calculation

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId 'com.brewtracker.android'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 190
-        versionName "3.2.5"
+        versionCode 191
+        versionName "3.2.6"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
   <string name="app_name">BrewTracker</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>
-  <string name="expo_runtime_version">3.2.5</string>
+  <string name="expo_runtime_version">3.2.6</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
 </resources>

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "BrewTracker",
     "slug": "brewtracker-android",
     "orientation": "portrait",
-    "version": "3.2.5",
+    "version": "3.2.6",
     "icon": "./assets/images/BrewTrackerAndroidLogo.png",
     "scheme": "brewtracker",
     "userInterfaceStyle": "automatic",
@@ -16,7 +16,7 @@
       },
       "edgeToEdgeEnabled": true,
       "package": "com.brewtracker.android",
-      "versionCode": 190,
+      "versionCode": 191,
       "permissions": [
         "CAMERA",
         "VIBRATE",
@@ -58,7 +58,7 @@
       }
     },
     "owner": "jackmisner",
-    "runtimeVersion": "3.2.5",
+    "runtimeVersion": "3.2.6",
     "updates": {
       "url": "https://u.expo.dev/edf222a8-b532-4d12-9b69-4e7fbb1d41c2"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brewtracker",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brewtracker",
-      "version": "3.2.5",
+      "version": "3.2.6",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@expo/metro-runtime": "~6.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brewtracker",
   "main": "expo-router/entry",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "license": "GPL-3.0-or-later",
   "scripts": {
     "start": "expo start",

--- a/src/components/recipes/AIAnalysisButton.tsx
+++ b/src/components/recipes/AIAnalysisButton.tsx
@@ -21,14 +21,13 @@
  * ```
  */
 
-import { useContext } from "react";
 import { TouchableOpacity, Text, ActivityIndicator, View } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 
 import { useTheme } from "@contexts/ThemeContext";
 import { createAIStyles } from "@styles/ai/aiStyles";
 import { TEST_IDS } from "@src/constants/testIDs";
-import NetworkContext from "@/src/contexts/NetworkContext";
+import { useNetwork } from "@/src/contexts/NetworkContext";
 
 interface AIAnalysisButtonProps {
   /**
@@ -76,8 +75,7 @@ export function AIAnalysisButton({
 }: AIAnalysisButtonProps) {
   const theme = useTheme();
   const styles = createAIStyles(theme);
-  const useNetwork = useContext(NetworkContext);
-  const isOffline = useNetwork?.isOffline ?? true;
+  const { isOffline } = useNetwork();
   const isDisabled = disabled || isOffline || loading;
   const displayLabel = loading
     ? loadingLabel
@@ -131,7 +129,8 @@ export function AIAnalysisIconButton({
 }: Pick<AIAnalysisButtonProps, "loading" | "disabled" | "onPress" | "testID">) {
   const theme = useTheme();
   const styles = createAIStyles(theme);
-  const isDisabled = disabled || loading;
+  const { isOffline } = useNetwork();
+  const isDisabled = disabled || isOffline || loading;
 
   return (
     <TouchableOpacity

--- a/src/components/recipes/AIAnalysisButton.tsx
+++ b/src/components/recipes/AIAnalysisButton.tsx
@@ -21,13 +21,14 @@
  * ```
  */
 
-import React from "react";
+import { useContext } from "react";
 import { TouchableOpacity, Text, ActivityIndicator, View } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 
 import { useTheme } from "@contexts/ThemeContext";
 import { createAIStyles } from "@styles/ai/aiStyles";
 import { TEST_IDS } from "@src/constants/testIDs";
+import NetworkContext from "@/src/contexts/NetworkContext";
 
 interface AIAnalysisButtonProps {
   /**
@@ -75,9 +76,14 @@ export function AIAnalysisButton({
 }: AIAnalysisButtonProps) {
   const theme = useTheme();
   const styles = createAIStyles(theme);
-
-  const isDisabled = disabled || loading;
-  const displayLabel = loading ? loadingLabel : label;
+  const useNetwork = useContext(NetworkContext);
+  const isOffline = useNetwork?.isOffline ?? true;
+  const isDisabled = disabled || isOffline || loading;
+  const displayLabel = loading
+    ? loadingLabel
+    : isOffline
+      ? "Go Online to Analyse with AI"
+      : label;
 
   return (
     <TouchableOpacity

--- a/src/services/brewing/OfflineMetricsCalculator.ts
+++ b/src/services/brewing/OfflineMetricsCalculator.ts
@@ -104,9 +104,10 @@ export class OfflineMetricsCalculator {
       }
     }
 
-    // Default attenuation if none specified
+    // Use 0% attenuation if no yeast is present (matches backend behavior)
+    // This results in FG = OG when there's no yeast
     const averageAttenuation =
-      attenuationCount > 0 ? totalAttenuation / attenuationCount : 75; // Default 75% attenuation
+      attenuationCount > 0 ? totalAttenuation / attenuationCount : 0;
 
     // Calculate FG: FG = OG - ((OG - 1) * attenuation/100)
     const gravityPoints = (og - 1) * 1000;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Analysis button now detects network connectivity, shows "Go Online to Analyse with AI" when offline, and disables analysis without a connection.

* **Improvements**
  * Offline brewing metrics refined so final gravity defaults more accurately when yeast data is missing.

* **Chores**
  * App version bumped to 3.2.6 (build 191).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->